### PR TITLE
Rename mat2dataframes to mat2dataframe

### DIFF
--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -6,7 +6,7 @@ import scipy.io
 from sklearn.decomposition import PCA
 from sklearn.decomposition import FactorAnalysis
 
-def mat2dataframes(path):
+def mat2dataframe(path):
     mat = scipy.io.loadmat(path, simplify_cells=True)
     df = pd.DataFrame(mat['trial_data'])
 


### PR DESCRIPTION
It creates just 1 dataframe.
I might like `mat2df` even better