### PR TITLE
Rewrite smoothing

### DIFF
--- a/pyaldata/Tools.py
+++ b/pyaldata/Tools.py
@@ -15,7 +15,7 @@ def smooth_signals(trial_data, signals, std=None, hw=None):
     ----------
     trial_data: pd.DataFrame
         trial data
-    signals: list of strings or ints
+    signals: list of strings
         signals to be smoothed
     std : float (optional)
         standard deviation of the smoothing window
@@ -40,8 +40,9 @@ def smooth_signals(trial_data, signals, std=None, hw=None):
 
     win = utils.norm_gauss_window(bin_size, std)
 
-    # TODO make signals iterable if it isn't
-    
+    if isinstance(signals, str):
+        signals = [signals]
+
     for (i, trial) in trial_data_exit.iterrows():
         for sig in signals:
             trial_data_exit.at[i, sig] = utils.smooth_data(trial[sig], win=win)


### PR DESCRIPTION
Rewrote `utils.smooth_data`

Kept the same first arguments not to break Catia's existing code.
Can handle 1D and 2D arrays.
Switches to scipy.signal.convolve with the method="same" to keep the original size of the arrays.
Can be used with a smoothing window, standard deviation or half-width.