### PR TITLE
Add add_norm function

### DIFF
--- a/pyaldata/tools.py
+++ b/pyaldata/tools.py
@@ -278,3 +278,27 @@ def binTD (trial_data, num_bins, isSpikes):
     
     return trial_data
 
+
+
+@utils.copy_td
+def add_norm(trial_data, signal):
+    """
+    Add the norm of the signal to the dataframe
+
+    Parameters
+    ----------
+    trial_data : pd.DataFrame
+        trial_data dataframe
+    signal : str
+        field to take the norm of
+
+    Returns
+    -------
+    td : pd.DataFrame
+        trial_data with '_norm' fields added
+    """
+    norm_field_name = signal + "_norm"
+
+    trial_data[norm_field_name] = [np.linalg.norm(s, axis=1) for s in trial_data[signal]]
+
+    return trial_data


### PR DESCRIPTION
Adds a new field with `_norm` appended to the original signal's name.

Fixes #13 