### PR TITLE
Add functions for dimensionality reduction

### DIFF
--- a/pyaldata/tools.py
+++ b/pyaldata/tools.py
@@ -278,3 +278,104 @@ def binTD (trial_data, num_bins, isSpikes):
     
     return trial_data
 
+
+
+def fit_dim_reduce_model(trial_data, model, signal, train_trials=None, fit_kwargs=None):
+    """
+    Fit a dimensionality reduction model to train_trials
+
+    Parameters
+    ----------
+    trial_data : pd.DataFrame
+        data in trial_data format
+    model : dimensionality reduction model
+        model to fit
+        has to implement a .fit (and .transform) method
+    signal : str
+        signal to fit to
+    train_trials : list of ints (optional)
+        trials to fit the model to
+    fit_kwargs : dict (optional)
+        parameters to pass to model.fit
+
+    Returns
+    -------
+    fitted model
+
+    Example
+    -------
+        from sklearn.decomposition import PCA
+        pca_dims = -5
+        pca = fit_dim_reduce_model(trial_data, PCA(pca_dims), 'M1_rates')
+    """
+    if fit_kwargs is None:
+        fit_kwargs = {}
+
+    model.fit(utils.concat_trials(trial_data, signal, train_trials),
+              **fit_kwargs)
+
+    return model
+
+
+@utils.copy_td
+def apply_dim_reduce_model(trial_data, model, signal, out_fieldname):
+    """
+    Apply a fitted dimensionality reduction model to all trials
+
+    Parameters
+    ----------
+    trial_data : pd.DataFrame
+        data in trial_data format
+    model : dimensionality reduction model
+        fitted model
+        has to implement a .transform method
+    signal : str
+        signal to apply to
+    out_fieldname : str
+        name of the field in which to store the transformed values
+
+    Returns
+    -------
+    trial_data with out_fieldname added
+    """
+    trial_data[out_fieldname] = [model.transform(s) for s in trial_data[signal]]
+
+    return trial_data
+
+
+@utils.copy_td
+def dim_reduce(trial_data, model, signal, out_fieldname, train_trials=None, fit_kwargs=None, return_model=False):
+    """
+    Fit dimensionality reduction model and apply it to all trials
+
+    Parameters
+    ----------
+    trial_data : pd.DataFrame
+        data in trial_data format
+    model : dimensionality reduction model
+        model to fit
+        has to implement a .fit and .transform method
+    signal : str
+        signal to fit and transform
+    out_fieldname : str
+        name of the field in which to store the transformed values
+    train_trials : list of ints (optional)
+        trials to fit the model to
+    fit_kwargs : dict (optional)
+        parameters to pass to model.fit
+    return_model : bool (optional, default False)
+        return the fitted model along with the data
+
+    Returns
+    -------
+    if return_model is False
+        trial_data with the projections added in out_fieldname
+    if return_model is True
+        (trial_data, model)
+    """
+    model = fit_dim_reduce_model(trial_data, model, signal, train_trials, fit_kwargs)
+
+    if return_model:
+        return (apply_dim_reduce_model(trial_data, model, signal, out_fieldname), model)
+    else:
+        return apply_dim_reduce_model(trial_data, model, signal, out_fieldname)


### PR DESCRIPTION
- `fit_dim_reduce_model` fits a model to a given signal in the data and returns the model
- `apply_dim_reduce_model` applies a fitted model to a given signal and adds a new field to the dataframe
- `dim_reduce` fits a model, applies it to every trial, and adds a new field

Fitting can be done on just training trials.

`model` can be anything that implements `.fit(X)` and `.transform(X)` methods where `X` is a `samples x features` array. This way we don't have to have include every method we might use, just pass a model object to this function.

I left the `utils.DimReduce` function to not break existing code. I noticed that it saved model parameters in a dict. That is replicated in `dim_reduce` by a `return_model` argument to return the fitted model along with the data if we want to use it later or look at `pca.explained_variance_ratio_` and stuff like that. Alternatively, just use the other two functions instead.

Fixes #10 