### PR TITLE
Add backshift_idx_fields function and add it to mat2dataframe

### DIFF
--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -11,9 +11,29 @@ from sklearn.decomposition import FactorAnalysis
 
 import functools
 
-def mat2dataframe(path):
+def mat2dataframe(path, shift_idx_fields):
+    """
+    Load a trial_data .mat file and turn it into a pandas DataFrame
+
+    Parameters
+    ----------
+    path : str
+        path to the .mat file
+    shift_idx_fields : bool
+        whether to shift the idx fields
+        set to True if the data was exported from matlab
+        using its 1-based indexig
+
+    Returns
+    -------
+    df : pd.DataFrame
+        pandas dataframe replicating the trial_data format
+    """
     mat = scipy.io.loadmat(path, simplify_cells=True)
     df = pd.DataFrame(mat['trial_data'])
+
+    if shift_idx_fields:
+        df = backshift_idx_fields(df)
 
     return df 
 
@@ -232,3 +252,25 @@ def dimReduce(data, params):
     
     return out_info
 
+
+@copy_td
+def backshift_idx_fields(trial_data):
+    """
+    Adjust index fields from 1-based to 0-based indexing
+
+    Parameters
+    ----------
+    trial_data : pd.DataFrame
+        data in trial_data format
+
+    Returns
+    -------
+    trial_data with the 'idx_' fields adjusted
+    """
+    idx_fields = [col for col in trial_data.columns.values if col.startswith("idx")]
+
+    for col in idx_fields:
+        # using a list comprehension to still work if the idx field itself is an array
+        trial_data[col] = [idx - 1 for idx in trial_data[col]]
+
+    return trial_data


### PR DESCRIPTION
I decided that the `shift_idx_fields` should be explicitly given instead of setting it to true by default so that we are always aware that it's happening.
Existing code will have to be adapted accordingly.

Fixes #24 