### PR TITLE
Restrict time to interval

### DIFF
--- a/pyaldata/tools.py
+++ b/pyaldata/tools.py
@@ -6,6 +6,7 @@ from sklearn.decomposition import PCA
 from sklearn.decomposition import FactorAnalysis
 from . import utils
 
+import warnings
 
 @utils.copy_td
 def smooth_signals(trial_data, signals, std=None, hw=None):
@@ -400,6 +401,7 @@ def merge_signals(trial_data, signals, out_fieldname):
 def add_norm(trial_data, signal):
     """
     Add the norm of the signal to the dataframe
+
     Parameters
     ----------
     trial_data : pd.DataFrame
@@ -654,6 +656,55 @@ def transform_signal(trial_data, signal, transformations, train_trials=None, **k
     for trans in transformations:
         trial_data = method_dict[trans](trial_data, signal, train_trials, **kwargs)
 
+
+@utils.copy_td
+def restrict_to_interval(trial_data, start_point_name, end_point_name=None, before=0, after=0):
+    """
+    Restrict time-varying fields to an interval around a time point or between two time points
+
+    trial_data : pd.DataFrame
+        data in trial_data format
+    start_point_name : str
+        name of the time point around which the interval starts
+    end_point_name : str, optional
+        name of the time point around which the interval ends
+        if None, the interval is created around start_point_name
+    before : int, optional, default 0
+        number of time points to extract before the starting time point
+    after : int, optional, default 0
+        number of time points to extract after the ending time point
+
+    Returns
+    -------
+    data in trial_data format
+    """
+    idx_fields = [col for col in trial_data.columns.values if col.startswith("idx")]
+    time_fields = utils.get_time_varying_fields(trial_data)
+
+    if (end_point_name is None) and (before == 0) and (after == 0):
+        warnings.warn("Extracting only one time point instead of an interval.")
+
+    # extract given interval from the time-varying fields
+    if end_point_name is None:
+        epoch_fun = lambda trial: utils.slice_around_point(trial, start_point_name, before, after)
+    else:
+        epoch_fun = lambda trial: utils.slice_between_points(trial, start_point_name, end_point_name, before, after)
+
+    for col in time_fields:
+        trial_data[col] = utils.extract_interval_from_signal(trial_data, col, epoch_fun)
+
+    # adjust idx fields
+    new_time_lengths = [arr.shape[0] for arr in trial_data[time_fields[0]]]
+    zero_points = [p - before for p in trial_data[start_point_name]]
+
+    for col in idx_fields:
+        trial_data[col] = [idx - zero_point for (idx, zero_point) in zip(trial_data[col], zero_points)]
+
+        # set indices that are now invalid (i.e. not in the restricted interval) to nan
+        trial_data[col] = [np.nan
+                           if ((idx < 0) or (idx > new_T))
+                           else idx
+                           for (idx, new_T) in zip(trial_data[col], new_time_lengths)]
 
     return trial_data
 

--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -475,4 +475,23 @@ def slice_between_points(trial, start_point_name, end_point_name, before, after)
     """
 
     return slice(trial[start_point_name]-before, trial[end_point_name]+after+1)
->>>>>>> 63764c4 (Add basic functions for slicing time in trials)
+
+
+def extract_interval_from_signal(trial_data, signal, epoch_fun):
+    """
+    Extract an interval from a time-varying signal in the dataset
+
+    Parameters
+    ----------
+    trial_data : pd.DataFrame
+        data in trial_data format
+    signal : str
+        name of the signal to extract
+    epoch_fun : function
+        function that takes a trial and returns the epoch to extract
+
+    Returns
+    -------
+    list of the extracted np.arrays
+    """
+    return [trial[signal][epoch_fun(trial), :] for (i, trial) in trial_data.iterrows()]

--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -405,3 +405,74 @@ def get_time_varying_fields(trial_data, ref_field=None):
 
     return time_fields
 
+
+def slice_around_index(idx, before, after):
+    """
+    Return a slice around an index
+    Length will be before + after + 1
+
+    Parameters
+    ----------
+    idx : int
+        index around which to create the interval
+    before : int
+        number of time points before time point
+    after : int
+        number of time points after time point
+
+    Returns
+    -------
+    slice(idx-before, idx+after+1)
+    """
+    return slice(idx-before, idx+after+1)
+
+
+def slice_around_point(trial, point_name, before, after):
+    """
+    Return a slice around a time point in the trial
+    Length will be before + after + 1
+
+    Parameters
+    ----------
+    trial : pd.Series
+        a row from a trial_data dataframe
+        representing a trial
+    point_name : str
+        name of the time point around which to create the interval
+    before : int
+        number of time points before time point
+    after : int
+        number of time points after time point
+
+    Returns
+    -------
+    slice object
+    """
+    return slice_around_index(trial[point_name], before, after)
+
+
+def slice_between_points(trial, start_point_name, end_point_name, before, after):
+    """
+    Return a slice that starts before start_point_name and ends after end_point_name
+
+    Parameters
+    ----------
+    trial : pd.Series
+        a row from a trial_data dataframe
+        representing a trial
+    start_point_name : str
+        name of the time point around which the interval starts
+    end_point_name : str
+        name of the time point around which the interval ends
+    before : int
+        number of time points before time point
+    after : int
+        number of time points after time point
+
+    Returns
+    -------
+    slice object
+    """
+
+    return slice(trial[start_point_name]-before, trial[end_point_name]+after+1)
+>>>>>>> 63764c4 (Add basic functions for slicing time in trials)


### PR DESCRIPTION
Add functionality to extract parts of trials.
Probably the main addition is `restrict_to_interval`

Fixes #22 

Also, I added  a `get_time_varying_fields` that tries to identify every field in the dataframe that seems to have a time dimension.