### PR TITLE
Fix mat2dataframe

### DIFF
--- a/pyaldata/tools.py
+++ b/pyaldata/tools.py
@@ -1003,4 +1003,3 @@ def remove_low_firing_neurons(trial_data, signal, threshold, divide_by_bin_size=
     trial_data[unit_guide] = [arr[mask, :] for arr in trial_data[unit_guide]]
 
     return trial_data
-


### PR DESCRIPTION
Fix `mat2dataframe` to not need the data to be named trial_data.

Fixes #49 