### PR TITLE
Extend transformation functions to handle multiple columns

### DIFF
--- a/pyaldata/tools.py
+++ b/pyaldata/tools.py
@@ -422,7 +422,7 @@ def add_norm(trial_data, signal):
     
 
 @utils.copy_td
-def center_signal(trial_data, signal, train_trials=None):
+def center_signal(trial_data, signals, train_trials=None):
     """
     Center signal by removing the mean across time
 
@@ -431,9 +431,8 @@ def center_signal(trial_data, signal, train_trials=None):
     ----------
     trial_data : pd.DataFrame
         data in trial_data format
-    signal : str
+    signals : str or list of str
         column to center
-        TODO extend to multiple columns
     train_trials : list of int
         indices of the trials to consider when calculating the mean
 
@@ -442,16 +441,20 @@ def center_signal(trial_data, signal, train_trials=None):
     trial_data : pd.DataFrame
         data with the given field centered
     """
-    whole_signal = utils.concat_trials(trial_data, signal, train_trials)
-    col_mean = np.mean(whole_signal, axis=0)
+    if isinstance(signals, str):
+        signals = [signals]
 
-    trial_data[signal] = [s - col_mean for s in trial_data[signal]]
+    for signal in signals:
+        whole_signal = utils.concat_trials(trial_data, signal, train_trials)
+        col_mean = np.mean(whole_signal, axis=0)
+
+        trial_data[signal] = [s - col_mean for s in trial_data[signal]]
 
     return trial_data
 
 
 @utils.copy_td
-def z_score_signal(trial_data, signal, train_trials=None):
+def z_score_signal(trial_data, signals, train_trials=None):
     """
     z-score signal by removing the mean across time
     and dividing by the standard deviation
@@ -461,9 +464,8 @@ def z_score_signal(trial_data, signal, train_trials=None):
     ----------
     trial_data : pd.DataFrame
         data in trial_data format
-    signal : str
+    signals : str or list of str
         column to z-score
-        TODO extend to multiple columns
     train_trials : list of int
         indices of the trials to consider when calculating the mean and std
 
@@ -472,17 +474,21 @@ def z_score_signal(trial_data, signal, train_trials=None):
     trial_data : pd.DataFrame
         data with the given field z-scored
     """
-    whole_signal = utils.concat_trials(trial_data, signal, train_trials)
-    col_mean = np.mean(whole_signal, axis=0)
-    col_std = np.std(whole_signal, axis=0)
+    if isinstance(signals, str):
+        signals = [signals]
 
-    trial_data[signal] = [(s - col_mean) / col_std for s in trial_data[signal]]
+    for signal in signals:
+        whole_signal = utils.concat_trials(trial_data, signal, train_trials)
+        col_mean = np.mean(whole_signal, axis=0)
+        col_std = np.std(whole_signal, axis=0)
+
+        trial_data[signal] = [(s - col_mean) / col_std for s in trial_data[signal]]
 
     return trial_data
 
 
 @utils.copy_td
-def sqrt_transform_signal(trial_data, signal, train_trials=None):
+def sqrt_transform_signal(trial_data, signals, train_trials=None):
     """
     square-root transform signal
 
@@ -490,9 +496,8 @@ def sqrt_transform_signal(trial_data, signal, train_trials=None):
     ----------
     trial_data : pd.DataFrame
         data in trial_data format
-    signal : str
+    signals : str
         column to transform
-        TODO extend to multiple columns
     train_trials : list of int
         warning: not used, only here for consistency with other functions
         indices of the trials to consider when calculating the mean and std
@@ -505,18 +510,22 @@ def sqrt_transform_signal(trial_data, signal, train_trials=None):
     if train_trials is not None:
         utils.warnings.warn("train_trials is not used in sqrt_transform")
 
-    for s in trial_data[signal]:
-        if (s < 0).any():
-            raise ValueError("signal cannot contain negative values when square-root transforming")
+    if isinstance(signals, str):
+        signals = [signals]
 
-    trial_data[signal] = [np.sqrt(s) for s in trial_data[signal]]
+    for signal in signals:
+        for s in trial_data[signal]:
+            if (s < 0).any():
+                raise ValueError("signal cannot contain negative values when square-root transforming")
+
+        trial_data[signal] = [np.sqrt(s) for s in trial_data[signal]]
 
 
     return trial_data
 
 
 @utils.copy_td
-def zero_normalize_signal(trial_data, signal, train_trials=None):
+def zero_normalize_signal(trial_data, signals, train_trials=None):
     """
     Zero-normalize signal to 0-1 by removing the minimum, then dividing by the range
 
@@ -525,9 +534,8 @@ def zero_normalize_signal(trial_data, signal, train_trials=None):
     ----------
     trial_data : pd.DataFrame
         data in trial_data format
-    signal : str
+    signals : str
         column to normalize
-        TODO extend to multiple columns
     train_trials : list of int
         indices of the trials to consider when calculating the minimum and range
 
@@ -536,17 +544,21 @@ def zero_normalize_signal(trial_data, signal, train_trials=None):
     trial_data : pd.DataFrame
         data with the given field normalized
     """
-    whole_signal = utils.concat_trials(trial_data, signal, train_trials)
-    col_min = np.min(whole_signal, axis=0)
-    col_range = utils.get_range(whole_signal, axis=0)
+    if isinstance(signals, str):
+        signals = [signals]
 
-    trial_data[signal] = [(s - col_min) / col_range for s in trial_data[signal]]
+    for signal in signals:
+        whole_signal = utils.concat_trials(trial_data, signal, train_trials)
+        col_min = np.min(whole_signal, axis=0)
+        col_range = utils.get_range(whole_signal, axis=0)
+
+        trial_data[signal] = [(s - col_min) / col_range for s in trial_data[signal]]
 
     return trial_data
 
 
 @utils.copy_td
-def center_normalize_signal(trial_data, signal, train_trials=None):
+def center_normalize_signal(trial_data, signals, train_trials=None):
     """
     Center-normalize signal by removing the mean, then dividing by the range
 
@@ -555,9 +567,8 @@ def center_normalize_signal(trial_data, signal, train_trials=None):
     ----------
     trial_data : pd.DataFrame
         data in trial_data format
-    signal : str
+    signals : str
         column to normalize
-        TODO extend to multiple columns
     train_trials : list of int
         indices of the trials to consider when calculating the mean and range
 
@@ -566,17 +577,21 @@ def center_normalize_signal(trial_data, signal, train_trials=None):
     trial_data : pd.DataFrame
         data with the given field normalized
     """
-    whole_signal = utils.concat_trials(trial_data, signal, train_trials)
-    col_mean = np.mean(whole_signal, axis=0)
-    col_range = utils.get_range(whole_signal, axis=0)
+    if isinstance(signals, str):
+        signals = [signals]
 
-    trial_data[signal] = [(s - col_mean) / col_range for s in trial_data[signal]]
+    for signal in signals:
+        whole_signal = utils.concat_trials(trial_data, signal, train_trials)
+        col_mean = np.mean(whole_signal, axis=0)
+        col_range = utils.get_range(whole_signal, axis=0)
+
+        trial_data[signal] = [(s - col_mean) / col_range for s in trial_data[signal]]
 
     return trial_data
 
 
 @utils.copy_td
-def soft_normalize_signal(trial_data, signal, train_trials=None, alpha=5):
+def soft_normalize_signal(trial_data, signals, train_trials=None, alpha=5):
     """
     Soft normalize signal a la Churchland papers
 
@@ -584,9 +599,8 @@ def soft_normalize_signal(trial_data, signal, train_trials=None, alpha=5):
     ----------
     trial_data : pd.DataFrame
         data in trial_data format
-    signal : str
+    signals : str
         column to normalize
-        TODO extend to multiple columns
     train_trials : list of int
         indices of the trials to consider when calculating the range
     alpha : float, default 5
@@ -597,17 +611,21 @@ def soft_normalize_signal(trial_data, signal, train_trials=None, alpha=5):
     trial_data : pd.DataFrame
         data with the given field soft-normalized
     """
-    whole_signal = utils.concat_trials(trial_data, signal, train_trials)
+    if isinstance(signals, str):
+        signals = [signals]
 
-    norm_factor = utils.get_range(whole_signal) + alpha
+    for signal in signals:
+        whole_signal = utils.concat_trials(trial_data, signal, train_trials)
 
-    trial_data[signal] = [s / norm_factor for s in trial_data[signal]]
+        norm_factor = utils.get_range(whole_signal) + alpha
+
+        trial_data[signal] = [s / norm_factor for s in trial_data[signal]]
 
     return trial_data
 
 
 @utils.copy_td
-def transform_signal(trial_data, signal, transformations, train_trials=None, **kwargs):
+def transform_signal(trial_data, signals, transformations, train_trials=None, **kwargs):
     """
     Apply transformation(s) to signal
 
@@ -616,9 +634,8 @@ def transform_signal(trial_data, signal, transformations, train_trials=None, **k
     ----------
     trial_data : pd.DataFrame
         data in trial_data format
-    signal : str
+    signals : str
         column to normalize
-        TODO extend to multiple columns
     transformations : str or list of str
         transformations to apply
         if it's a list of strings, the corresponding transformations are applied in the given order
@@ -653,8 +670,12 @@ def transform_signal(trial_data, signal, transformations, train_trials=None, **k
     if isinstance(transformations, str):
         transformations = [transformations]
 
-    for trans in transformations:
-        trial_data = method_dict[trans](trial_data, signal, train_trials, **kwargs)
+    if isinstance(signals, str):
+        signals = [signals]
+
+    for signal in signals:
+        for trans in transformations:
+            trial_data = method_dict[trans](trial_data, signal, train_trials, **kwargs)
 
     return trial_data
 


### PR DESCRIPTION
Transforming signals one-by-one was annoying. Now we can do `df = center_signal(df, ["M1_rates", "PMd_rates"])`
`transform_signal` and co. work the same way.