### PR TITLE
Add `generate_epoch_fun`

### DIFF
--- a/pyaldata/tools.py
+++ b/pyaldata/tools.py
@@ -600,13 +600,9 @@ def restrict_to_interval(trial_data, start_point_name=None, end_point_name=None,
     idx_fields = [col for col in trial_data.columns.values if col.startswith("idx")]
     time_fields = utils.get_time_varying_fields(trial_data, ref_field)
 
-
-    # extract given interval from the time-varying fields
+    # generate epoch_fun if the interval is given with time points
     if start_point_name is not None:
-        if end_point_name is None:
-            epoch_fun = lambda trial: utils.slice_around_point(trial, start_point_name, -rel_start, rel_end)
-        else:
-            epoch_fun = lambda trial: utils.slice_between_points(trial, start_point_name, end_point_name, -rel_start, rel_end)
+        epoch_fun = utils.generate_epoch_fun(start_point_name, end_point_name, rel_start, rel_end)
 
     # check in which trials the indexing works properly
     kept_trials_mask = np.array([utils._slice_in_trial(trial, epoch_fun(trial), warn_per_trial)

--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -688,4 +688,13 @@ def _slice_in_trial(trial, sl, warn=False):
         if warn:
             warnings.warn(f"Invalid time index on trial with ID {trial.trial_id}. Trying to access index {sl.stop-1} >= {T}")
 
+    if not np.isfinite(sl.start):
+        is_inside = False
+        if warn:
+            warnings.warn(f"Invalid time index on trial with ID {trial.trial_id}. Starting point is {sl.start}")
+    if not np.isfinite(sl.stop):
+        is_inside = False
+        if warn:
+            warnings.warn(f"Invalid time index on trial with ID {trial.trial_id}. End point is {sl.stop}")
+
     return is_inside

--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -486,7 +486,15 @@ def slice_around_index(idx, before, after):
     -------
     slice(idx-before, idx+after+1)
     """
-    return slice(idx-before, idx+after+1)
+    start = idx - before
+    end = idx + after + 1
+
+    if np.isfinite(start):
+        start = int(start)
+    if np.isfinite(end):
+        end = int(end)
+
+    return slice(start, end)
 
 
 def slice_around_point(trial, point_name, before, after):
@@ -510,7 +518,15 @@ def slice_around_point(trial, point_name, before, after):
     -------
     slice object
     """
-    return slice_around_index(trial[point_name], before, after)
+    start = trial[point_name] - before
+    end = trial[point_name] + after + 1
+
+    if np.isfinite(start):
+        start = int(start)
+    if np.isfinite(end):
+        end = int(end)
+
+    return slice(start, end)
 
 
 def slice_between_points(trial, start_point_name, end_point_name, before, after):
@@ -535,6 +551,17 @@ def slice_between_points(trial, start_point_name, end_point_name, before, after)
     -------
     slice object
     """
+    start = trial[start_point_name] - before
+    end = trial[end_point_name] + after + 1
+
+    if np.isfinite(start):
+        start = int(start)
+    if np.isfinite(end):
+        end = int(end)
+
+    return slice(start, end)
+
+
 def generate_epoch_fun(start_point_name, end_point_name=None, rel_start=0, rel_end=0):
     """
     Return a function that slices a trial around/between time points

--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -535,8 +535,35 @@ def slice_between_points(trial, start_point_name, end_point_name, before, after)
     -------
     slice object
     """
+def generate_epoch_fun(start_point_name, end_point_name=None, rel_start=0, rel_end=0):
+    """
+    Return a function that slices a trial around/between time points
 
-    return slice(trial[start_point_name]-before, trial[end_point_name]+after+1)
+    Parameters
+    ----------
+    start_point_name : str
+        name of the time point around which the interval starts
+    end_point_name : str, optional
+        name of the time point around which the interval ends
+        if None, the interval is created around start_point_name
+    rel_start : int, default 0
+        when to start extracting relative to the starting time point
+        replaces the 'before' option
+    rel_end : int, default 0
+        when to stop extracting relative to the ending time point
+        replaces the 'after' option
+
+    Returns
+    -------
+    epoch_fun : function
+        function that can be used to extract the interval from a trial
+    """
+    if end_point_name is None:
+        epoch_fun = lambda trial: slice_around_point(trial, start_point_name, -rel_start, rel_end)
+    else:
+        epoch_fun = lambda trial: slice_between_points(trial, start_point_name, end_point_name, -rel_start, rel_end)
+
+    return epoch_fun
 
 
 def extract_interval_from_signal(trial_data, signal, epoch_fun):


### PR DESCRIPTION
Add a function for generating functions that can be used for extracting epochs from trials. Useful for extracting the same epoch from multiple dataframes. A simple spin on an idea from @AtMostafa

Example:
```python
exec_epoch = generate_epoch_fun('idx_go_cue', rel_start=0, rel_end=50)
exec_a = restrict_to_interval(df_a, epoch_fun=exec_epoch)
exec_b = restrict_to_interval(df_b, epoch_fun=exec_epoch)
```

Also touch up how the slices are generated and how `_slice_in_trial` checks if we can extract an interval from a trial or not.
Might fix #102 