### PR TITLE
Clean fields when loading

### DIFF
--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -698,3 +698,62 @@ def _slice_in_trial(trial, sl, warn=False):
             warnings.warn(f"Invalid time index on trial with ID {trial.trial_id}. End point is {sl.stop}")
 
     return is_inside
+
+
+@copy_td
+def clean_0d_array_fields(df):
+    """
+    Loading v7.3 MAT files, sometimes scalers are stored as 0-dimensional arrays for some reason.
+    This converts those back to scalars.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        data in trial_data format
+
+    Returns
+    -------
+    a copy of df with the relevant fields changed
+    """
+    for c in df.columns:
+        if isinstance(df[c].values[0], np.ndarray):
+            if all([arr.ndim == 0 for arr in df[c]]):
+                df[c] = [arr.item() for arr in df[c]]
+
+    return df
+
+
+@copy_td
+def clean_integer_fields(df):
+    """
+    Modify fields that store integers as floats to store them as integers instead.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        data in trial_data format
+
+    Returns
+    -------
+    a copy of df with the relevant fields changed
+    """
+    for field in df.columns:
+        if isinstance(df[field].values[0], np.ndarray):
+            try:
+                int_arrays = [np.int32(arr) for arr in df[field]]
+            except:
+                print(f"array field {field} could not be converted to int.")
+            else:
+                if all([np.allclose(int_arr, arr) for (int_arr, arr) in zip(int_arrays, df[field])]):
+                    df[field] = int_arrays
+        else:
+            if not isinstance(df[field].values[0], str):
+                try:
+                    int_version = np.int32(df[field])
+                except:
+                        print(f"field {field} could not be converted to int.")
+                else:
+                    if np.allclose(int_version, df[field]):
+                        df[field] = int_version
+
+    return df

--- a/pyaldata/utils.py
+++ b/pyaldata/utils.py
@@ -59,6 +59,9 @@ def mat2dataframe(path, shift_idx_fields, td_name=None):
 
     df = pd.DataFrame(mat[td_name])
 
+    df = clean_0d_array_fields(df)
+    df = clean_integer_fields(df)
+
     if shift_idx_fields:
         df = backshift_idx_fields(df)
 


### PR DESCRIPTION
In order to avoid weird errors, clean fields that store scalars as 0D arrays and fields that store integers as floats when loading .MAT files.